### PR TITLE
3.0.0 candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,27 @@
 env:
   global:
-  - TF_VERSION=0.11.11
-  - GOOGLE_APPLICATION_CREDENTIALS=sa-gcp.json
+    - TF_VERSION=0.11.14
+    - GOOGLE_APPLICATION_CREDENTIALS=sa-gcp.json
 sudo: required
 language: bash
 before_install:
-- openssl aes-256-cbc -K $encrypted_6d375b8dd7c7_key -iv $encrypted_6d375b8dd7c7_iv
-  -in sa-gcp.json.enc -out sa-gcp.json -d
-- wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
-  -O /tmp/terraform.zip
-- sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
-- gcloud version || true
-- if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export
-  CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
-- source /home/travis/google-cloud-sdk/path.bash.inc
-- gcloud version
+  - openssl aes-256-cbc -K $encrypted_6d375b8dd7c7_key -iv $encrypted_6d375b8dd7c7_iv
+    -in sa-gcp.json.enc -out sa-gcp.json -d
+  - wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip
+    -O /tmp/terraform.zip
+  - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
+  - gcloud version || true
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud version
 cache:
   directories:
-  - "$HOME/google-cloud-sdk/"
+    - "$HOME/google-cloud-sdk/"
 script:
-- gcloud auth activate-service-account travis-terraform-tests@fleet-goal-232910.iam.gserviceaccount.com --key-file=sa-gcp.json
-- make fmt
-- make validate
-- make test
-- make destroy
+  - gcloud auth activate-service-account travis-terraform-tests@fleet-goal-232910.iam.gserviceaccount.com --key-file=sa-gcp.json
+  - make fmt
+  - make validate
+  - make test
+  - make nat_verify
+  - make destroy

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 modules = $(shell find . -type f -name "*.tf" -exec dirname {} \;|sort -u)
+google_region = $(shell grep -r region tests/tests.tfvars | awk '{print $$3}')
+google_project = $(shell grep -r project tests/tests.tfvars | awk '{print $$3}')
 test_dir=tests
 
 .PHONY: test
@@ -18,6 +20,19 @@ fmt: init
 test: init
 	terraform plan -var-file=$(test_dir)/tests.tfvars -out=.plan $(test_dir)
 	terraform apply ".plan"
+
+nat_verify: 
+	gcloud components install kubectl -q
+	gcloud container clusters get-credentials primary-cluster-regional-nat --region $(google_region) --project $(google_project)
+	### Waiting for dns in the cluster to be ready
+	until [ `kubectl run curl --rm --restart=Never -it --image=appropriate/curl --generator=run-pod/v1 --wait  -- -fsSL http://ifconfig.co |grep -oE '([0-9]{1,3}[\.]){3}[0-9]{1,3}'` ]; do echo "Waiting for dns in the cluster to be ready" ; sleep 60; done
+	### compare actual external IP with google NAT IP
+	ACTUAL_IP=`kubectl run curl --rm --restart=Never -it --image=appropriate/curl --generator=run-pod/v1 --wait  -- -fsSL http://ifconfig.co | grep -oE '([0-9]{1,3}[\.]){3}[0-9]{1,3}'` ;\
+	NAT_IP=`gcloud compute addresses describe default-primary-cluster-regional-nat-nat-external-address --region $(google_region) --project $(google_project) |grep 'address:'| awk '{print $$2}'` ;\
+	echo "Discovered IP is: $$ACTUAL_IP" ;\
+	echo "Google Nat IP is: $$NAT_IP" ;\
+	if [ "$$ACTUAL_IP" != "$$NAT_IP" ];then exit 1; fi
+
 
 destroy: init
 	terraform plan --destroy -var-file=$(test_dir)/tests.tfvars -out=.plan $(test_dir)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you need more control with versioning of your cluster, it is advised to speci
 module "primary-cluster" {
   name                   = "${terraform.workspace}"
   source                 = "russmedia/kubernetes-cluster/google"
-  version                = "2.3.0"
+  version                = "3.0.0"
   region                 = "${var.google_region}"
   zones                  = "${var.google_zones}"
   project                = "${var.project}"
@@ -62,7 +62,7 @@ module "primary-cluster" {
 module "primary-cluster" {
   name                   = "my-cluster"
   source                 = "russmedia/kubernetes-cluster/google"
-  version                = "2.3.0"
+  version                = "3.0.0"
   region                 = "${var.google_region}"
   zones                  = "${var.google_zones}"
   project                = "${var.project}"
@@ -80,8 +80,8 @@ node_pools = [
     name                = "default-pool"
     initial_node_count  = 1
     min_node_count      = 1
-    max_node_count      = 3
-    version             = "1.11.8-gke.4"
+    max_node_count      = 1
+    version             = "1.13.7-gke.24"
     image_type          = "COS"
     machine_type        = "n1-standard-1"
     preemptible         = true
@@ -107,7 +107,7 @@ resource "google_compute_network" "default" {
 module "primary-cluster" {
   name        = "primary-cluster"
   source      = "russmedia/kubernetes-cluster/google"
-  version     = "2.3.0"
+  version     = "3.0.0"
   region      = "${var.google_region}"
   zones       = "${var.google_zones}"
   project     = "${var.project}"
@@ -120,7 +120,7 @@ module "primary-cluster" {
 module "secondary-cluster" {
   name                                 = "secondary-cluster"
   source                               = "russmedia/kubernetes-cluster/google"
-  version                              = "2.3.0"
+  version                              = "3.0.0"
   region                               = "${var.google_region}"
   zones                                = "${var.google_zones}"
   project                              = "${var.project}"
@@ -167,6 +167,7 @@ Terraform always creates a subnetwork. The subnetwork name is taken from a patte
 
 - Zonal clusters: 
 A zonal cluster runs in one or more compute zones within a region. A multi-zone cluster runs its nodes across two or more compute zones within a single region. Zonal clusters run a single cluster master.
+**Important** zonal clusters from version 3.0.0 are using nodes only in the zone of the master. This is changed due to new nodes behavior on google cloud. Nodes in other zones can no longer register to cluster in a different zone.
 - Regional cluster:
 A regional cluster runs three cluster masters across three compute zones, and runs nodes in two or more compute zones.
 

--- a/modules/kubernetes_node_pools/main.tf
+++ b/modules/kubernetes_node_pools/main.tf
@@ -9,7 +9,7 @@ resource "google_container_node_pool" "node_pool" {
   count              = "${var.regional_cluster ? 0 : length(var.node_pools)}"
   location           = "${var.region}-${var.zones[0]}"
   cluster            = "${var.cluster_name}"
-  version            = "${lookup(var.node_pools[count.index], "version", "")}"
+  version            = "${lookup(var.node_pools[count.index], "version")}"
   project            = "${var.project}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count")}"
 

--- a/tests/google.tf
+++ b/tests/google.tf
@@ -8,5 +8,5 @@ terraform {
 provider "google" {
   project = "${var.project}"
   region  = "${var.region}"
-  version = "~> 2.3"
+  version = "~> 2.16"
 }

--- a/tests/tests.tfvars
+++ b/tests/tests.tfvars
@@ -8,4 +8,4 @@ zones = ["b", "c"]
 
 environment = "test"
 
-kube_version = "1.12.8-gke.10"
+kube_version = "1.13.7-gke.24"

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "region" {
 
 variable "zones" {
   type        = "list"
-  description = "Zones for Kubernetes workers"
+  description = "Zones for Kubernetes workers - please note - zonal cluster will spin out nodes in one zone only"
 }
 
 variable "regional_cluster" {


### PR DESCRIPTION
- Fixing node locations on regional clusters
- Fixing private_ip_google_access not persisting on second terraform run
- Adding new test to verify if nat ip is properly assigned
- Breaking change - zonal clusters now use nodes from only one zone (due to changes on google cloud)