### PR TITLE
allowing `no_schedule_taint` and `no_execute_taint` on node pools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - TF_VERSION=0.12.23
+    - TF_VERSION=0.13.6
     - GOOGLE_APPLICATION_CREDENTIALS=sa-gcp.json
 sudo: required
 language: bash

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ node_pools = [
 
 **Note: at least one node pool must have `initial_node_count` > 0.**
 
-## Since 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
+## Since version 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
 
 ```
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ node_pools = [
 
 **Note: at least one node pool must have `initial_node_count` > 0.**
 
-## Since version 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
+### Since version 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
 
 ```
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -91,7 +91,29 @@ node_pools = [
   },
 ]
 ```
+
+
 **Note: at least one node pool must have `initial_node_count` > 0.**
+
+## Since 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent
+  tolerations:
+  - key: "executable"
+    operator: "Exists"
+    effect: "NoSchedule"
+```
 
 ###  multiple clusters
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ node_pools = [
 
 **Note: at least one node pool must have `initial_node_count` > 0.**
 
-### Since version 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes i.e. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info:
+### Since version 5.0.0 module supports `no_schedule_taint` and `no_execute_taint` - they will add `schedulable=equals:NoSchedule` or `executable=equals:NoExecute` - which will effect in only specific nodes being scheduled on those nodes. Please see [k8s docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more info. 
+
+Example usage with "NoSchedule":
 
 ```
 apiVersion: v1
@@ -110,10 +112,32 @@ spec:
     image: nginx
     imagePullPolicy: IfNotPresent
   tolerations:
-  - key: "executable"
-    operator: "Exists"
-    effect: "NoSchedule"
+    - key: "schedulable"
+      operator: "Exists"
+      effect: "NoSchedule"
 ```
+
+Example usage with "NoExecute":
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    env: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    imagePullPolicy: IfNotPresent
+  tolerations:
+    - key: "executable"
+      operator: "Exists"
+      effect: "NoExecute"
+```
+
+**Note - if node has both taints NoExecute and NoSchedule - you need to add both tolerations to pod to be allowed there.**
 
 ###  multiple clusters
 

--- a/modules/kubernetes_node_pools/main.tf
+++ b/modules/kubernetes_node_pools/main.tf
@@ -46,7 +46,22 @@ resource "google_container_node_pool" "node_pool" {
         ),
       ),
     )
-
+    dynamic "taint" {
+      for_each = lookup(var.node_pools[count.index], "no_execute_taint", false) ? var.no_execute_taint : []
+      content {
+        effect = taint.value["effect"]
+        key    = taint.value["key"]
+        value  = taint.value["value"]
+      }
+    }
+    dynamic "taint" {
+      for_each = lookup(var.node_pools[count.index], "no_schedule_taint", false) ? var.no_schedule_taint : []
+      content {
+        effect = taint.value["effect"]
+        key    = taint.value["key"]
+        value  = taint.value["value"]
+      }
+    }
     tags = split(" ", var.node_pools[count.index]["tags"])
   }
 }
@@ -93,7 +108,22 @@ resource "google_container_node_pool" "node_pool_regional" {
         ),
       ),
     )
-
+    dynamic "taint" {
+      for_each = lookup(var.node_pools[count.index], "no_execute_taint", false) ? var.no_execute_taint : []
+      content {
+        effect = taint.value["effect"]
+        key    = taint.value["key"]
+        value  = taint.value["value"]
+      }
+    }
+    dynamic "taint" {
+      for_each = lookup(var.node_pools[count.index], "no_schedule_taint", false) ? var.no_schedule_taint : []
+      content {
+        effect = taint.value["effect"]
+        key    = taint.value["key"]
+        value  = taint.value["value"]
+      }
+    }
     tags = split(" ", var.node_pools[count.index]["tags"])
   }
 }

--- a/modules/kubernetes_node_pools/variables.tf
+++ b/modules/kubernetes_node_pools/variables.tf
@@ -25,6 +25,8 @@ variable "node_pools" {
       - image_type
       - machine_type
       - preemptible [bool]
+      - no_execute_taint [bool]
+      - no_schedule_taint [bool]
       - tags [space separated tags]
       - custom_label_keys [space separated tags, must match the number of custom_label_values]
       - custom_label_values [space separated tags, must match the number of custom_label_keys]
@@ -70,4 +72,23 @@ variable "regional_cluster" {
   default     = false
   description = "Set to `true` to create node pool for regional cluster."
 }
+variable "no_execute_taint" {
+  type        = list(map(any))
+  description = "Object containing node NoExecute taints"
 
+  default = [{
+    key    = "executable"
+    value  = "equals"
+    effect = "NO_EXECUTE"
+  }]
+}
+variable "no_schedule_taint" {
+  type        = list(map(any))
+  description = "Object containing node NoSchedule taints"
+
+  default = [{
+    key    = "schedulable"
+    value  = "equals",
+    effect = "NO_SCHEDULE"
+  }]
+}

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -59,7 +59,7 @@ module "primary-cluster-regional-nat" {
   nodes_subnet_service_ip_cidr_range   = "10.203.0.0/16"
   min_master_version                   = var.kube_version
 
-  #test with defined node pool (specific version)
+  #test with defined node pool (specific version with NoExecute and NoSchedule taint)
   node_pools = [
     {
       name               = "additional-pool"
@@ -70,6 +70,8 @@ module "primary-cluster-regional-nat" {
       image_type         = "COS"
       machine_type       = "n1-standard-1"
       preemptible        = false
+      no_execute_taint   = true
+      no_schedule_taint  = true
       tags               = "additional-pool worker"
     },
   ]

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -70,10 +70,20 @@ module "primary-cluster-regional-nat" {
       image_type         = "COS"
       machine_type       = "n1-standard-1"
       preemptible        = false
+      tags               = "additional-pool worker"
+      }, {
+      name               = "tainted-pool"
+      initial_node_count = 1
+      min_node_count     = 1
+      max_node_count     = 1
+      version            = var.kube_version
+      image_type         = "COS"
+      machine_type       = "n1-standard-1"
+      preemptible        = true
       no_execute_taint   = true
       no_schedule_taint  = true
       tags               = "additional-pool worker"
-    },
+    }
   ]
 
   node_pools_scopes = [

--- a/tests/tests.tfvars
+++ b/tests/tests.tfvars
@@ -8,4 +8,4 @@ zones = ["b", "c"]
 
 environment = "test"
 
-kube_version = "1.15.11-gke.3"
+kube_version = "1.17.15-gke.800"

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,8 @@ variable "node_pools" {
       - image_type
       - machine_type
       - preemptible [bool]
+      - no_execute_taint [bool]
+      - no_schedule_taint [bool]
       - tags [space separated tags]
       - custom_label_keys [space separated tags, must match the number of custom_label_values]
       - custom_label_values [space separated tags, must match the number of custom_label_keys]
@@ -126,4 +128,3 @@ variable "node_pools_scopes" {
 
   description = "list of OAuth scopes e.g.: https://www.googleapis.com/auth/compute], global per all node pools"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
- using terraform 0.13 dynamic block to add taints
- allowing `no_schedule_taint` and `no_execute_taint` on node pools 