### PR TITLE
Custom node locations per node pool, option to disable autoscaling & …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,8 @@ module "node-pool" {
   node_pools        = var.node_pools
   regional_cluster  = var.regional_cluster
   node_pools_scopes = var.node_pools_scopes
+  no_execute_taint  = var.no_execute_taint
+  no_schedule_taint = var.no_schedule_taint
 }
 
 resource "google_compute_network" "default" {

--- a/modules/kubernetes_node_pools/main.tf
+++ b/modules/kubernetes_node_pools/main.tf
@@ -12,10 +12,14 @@ resource "google_container_node_pool" "node_pool" {
   version            = var.node_pools[count.index]["version"]
   project            = var.project
   initial_node_count = var.node_pools[count.index]["initial_node_count"]
+  node_locations = lookup(var.node_pools[count.index], "custom_node_locations", "") != "" ? split(" ", var.node_pools[count.index]["custom_node_locations"]) : null
 
-  autoscaling {
-    min_node_count = var.node_pools[count.index]["min_node_count"]
-    max_node_count = var.node_pools[count.index]["max_node_count"]
+  dynamic "autoscaling" {
+    for_each = var.node_pools[count.index].disable_autoscaling ? [] : [1]
+    content {
+      min_node_count = contains(keys(var.node_pools[count.index]), "min_node_count") ? var.node_pools[count.index]["min_node_count"] : 0
+      max_node_count = contains(keys(var.node_pools[count.index]), "max_node_count") ? var.node_pools[count.index]["max_node_count"] : 1
+    }
   }
 
   node_config {
@@ -74,10 +78,14 @@ resource "google_container_node_pool" "node_pool_regional" {
   version            = var.node_pools[count.index]["version"]
   project            = var.project
   initial_node_count = var.node_pools[count.index]["initial_node_count"]
+  node_locations = lookup(var.node_pools[count.index], "custom_node_locations", "") != "" ? split(" ", var.node_pools[count.index]["custom_node_locations"]) : null
 
-  autoscaling {
-    min_node_count = var.node_pools[count.index]["min_node_count"]
-    max_node_count = var.node_pools[count.index]["max_node_count"]
+  dynamic "autoscaling" {
+    for_each = var.node_pools[count.index].disable_autoscaling ? [] : [1]
+    content {
+      min_node_count = contains(keys(var.node_pools[count.index]), "min_node_count") ? var.node_pools[count.index]["min_node_count"] : 0
+      max_node_count = contains(keys(var.node_pools[count.index]), "max_node_count") ? var.node_pools[count.index]["max_node_count"] : 1
+    }
   }
 
   node_config {

--- a/modules/kubernetes_node_pools/variables.tf
+++ b/modules/kubernetes_node_pools/variables.tf
@@ -30,6 +30,7 @@ variable "node_pools" {
       - tags [space separated tags]
       - custom_label_keys [space separated tags, must match the number of custom_label_values]
       - custom_label_values [space separated tags, must match the number of custom_label_keys]
+      - disable_autoscaling [bool]
   
 EOF
 
@@ -91,4 +92,9 @@ variable "no_schedule_taint" {
     value  = "equals",
     effect = "NO_SCHEDULE"
   }]
+}
+
+variable "disable_autoscaling" {
+  description = "Allows to disable autoscaling"
+  default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,7 @@ variable "node_pools" {
       machine_type       = "n1-standard-1"
       preemptible        = true
       tags               = "default-pool worker"
+      disable_autoscaling = false
     },
   ]
 
@@ -113,9 +114,33 @@ variable "node_pools" {
       - tags [space separated tags]
       - custom_label_keys [space separated tags, must match the number of custom_label_values]
       - custom_label_values [space separated tags, must match the number of custom_label_keys]
+      - disable_autoscaling [bool]
+      - custom_node_locations [space separated locations]
   
 EOF
 
+}
+
+variable "no_execute_taint" {
+  type        = list(map(any))
+  description = "Object containing node NoExecute taints"
+
+  default = [{
+    key    = "executable"
+    value  = "equals"
+    effect = "NO_EXECUTE"
+  }]
+}
+
+variable "no_schedule_taint" {
+  type        = list(map(any))
+  description = "Object containing node NoSchedule taints for all node pools"
+
+  default = [{
+    key    = "schedulable"
+    value  = "equals",
+    effect = "NO_SCHEDULE"
+  }]
 }
 
 variable "node_pools_scopes" {


### PR DESCRIPTION
**Features:**
- custom node locations per node pools
- customisable taints - still global per node pools with option to enable them on specific node pools
- option to disable autoscaling per node pool - required i.e. for Spotinst clusters, or when cost savings are need to narrow to single zone