### PR TITLE
Add output with cluster certificate.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,17 @@
 locals {
   network_name    = "${terraform.workspace}-${var.name}"
   subnetwork_name = "${terraform.workspace}-${var.name}-nodes-subnet"
+
+  cluster_output_master_auth      = coalescelist(
+    concat(google_container_cluster.primary.*.master_auth, []),
+    concat(google_container_cluster.primary-nat.*.master_auth, []),
+    concat(google_container_cluster.primary-regional.*.master_auth, []),
+    concat(google_container_cluster.primary-regional-nat.*.master_auth, [])
+  )
+  cluster_master_auth_list_layer1 = local.cluster_output_master_auth
+  cluster_master_auth_list_layer2 = local.cluster_master_auth_list_layer1[0]
+  cluster_master_auth_map         = local.cluster_master_auth_list_layer2[0]
+  cluster_ca_certificate          = local.cluster_master_auth_map["cluster_ca_certificate"]
 }
 
 resource "google_container_cluster" "primary" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,7 @@ output "outgoing_ip" {
   value = google_compute_address.address.*.address
 }
 
+output "cluster_ca_certificate" {
+  value     = local.cluster_ca_certificate
+  sensitive = true
+}


### PR DESCRIPTION
As a DevOps engineer, I want to be able to connect with Kubernetes provider as following:
```
data "google_client_config" "default" {}

provider "kubernetes" {
  host                   = "https://${module.primary-cluster.master_ip}"
  token                  = data.google_client_config.default.access_token
  cluster_ca_certificate = base64decode(module.primary-cluster.cluster_ca_certificate)
}
```

Currently, the cluster CA certificate is missing, this PR adds this output. Calculation logic comes from[ google official cluster ](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/main.tf#L101) and is modified to work with different types of clusters which the module is able to provision.